### PR TITLE
Add client download progress bar

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException, BackgroundTasks, Request
-from fastapi.responses import JSONResponse, HTMLResponse
+from fastapi.responses import JSONResponse, HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from typing import Optional, List, Dict, Any
@@ -334,6 +334,21 @@ async def delete_task_file(task_id: str):
     except Exception as e:
         logger.error(f"删除文件失败: {e}")
         raise HTTPException(status_code=500, detail=f"删除文件失败: {str(e)}")
+
+@app.get("/api/tasks/{task_id}/file")
+async def download_task_file(task_id: str):
+    """下载任务对应的视频文件"""
+    if task_id not in tasks:
+        raise HTTPException(status_code=404, detail="任务不存在")
+
+    task = tasks[task_id]
+    output_file = task["output_file"]
+    file_path = os.path.join(DOWNLOADS_DIR, output_file)
+
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="文件不存在")
+
+    return FileResponse(file_path, filename=output_file, media_type="application/octet-stream")
 
 @app.get("/api/tasks/{task_id}/progress")
 async def get_task_progress(task_id: str):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -322,9 +322,15 @@
             
             const fileActions = task.status === 'completed' ? `
                 <div class="file-actions">
+                    <button type="button" class="btn btn-success btn-sm me-2" id="downloadFileBtn">
+                        <i class="bi bi-download"></i> 下载视频
+                    </button>
                     <button type="button" class="btn btn-warning btn-sm" id="deleteFileBtn">
                         <i class="bi bi-trash"></i> 删除视频文件
                     </button>
+                    <div class="progress mt-2" id="downloadProgress" style="display:none;">
+                        <div class="progress-bar" role="progressbar" style="width: 0%"></div>
+                    </div>
                 </div>
             ` : '';
             
@@ -355,6 +361,13 @@
                     if (confirm('确定要删除此视频文件吗？删除后无法恢复！')) {
                         await deleteTaskFile(task.id);
                     }
+                });
+            }
+
+            const downloadFileBtn = taskDetailContent.querySelector('#downloadFileBtn');
+            if (downloadFileBtn) {
+                downloadFileBtn.addEventListener('click', async () => {
+                    await downloadTaskFile(task.id, task.output_file);
                 });
             }
             
@@ -479,6 +492,54 @@
             } catch (error) {
                 console.error('删除文件失败:', error);
                 alert(`删除文件失败: ${error.message}`);
+            }
+        }
+
+        // 下载任务文件并显示进度
+        async function downloadTaskFile(taskId, fileName) {
+            try {
+                const response = await fetch(`/api/tasks/${taskId}/file`);
+
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.detail || '下载文件失败');
+                }
+
+                const total = parseInt(response.headers.get('Content-Length')) || 0;
+                const reader = response.body.getReader();
+                let received = 0;
+                const chunks = [];
+                const progressContainer = document.getElementById('downloadProgress');
+                const progressBar = progressContainer.querySelector('.progress-bar');
+                progressContainer.style.display = 'block';
+
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    chunks.push(value);
+                    received += value.length;
+                    if (total) {
+                        const progress = (received / total) * 100;
+                        progressBar.style.width = `${progress}%`;
+                        progressBar.textContent = `${progress.toFixed(1)}%`;
+                    }
+                }
+
+                progressBar.style.width = '100%';
+                progressBar.textContent = '100%';
+
+                const blob = new Blob(chunks);
+                const url = window.URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = fileName;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+                window.URL.revokeObjectURL(url);
+            } catch (error) {
+                console.error('下载文件失败:', error);
+                alert(`下载文件失败: ${error.message}`);
             }
         }
         


### PR DESCRIPTION
## Summary
- allow downloading completed video files via GET `/api/tasks/{task_id}/file`
- show progress bar during file download on the detail modal
- add JS handler to stream and track download progress

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a679e6a20832a8e5b6062a94dbb15